### PR TITLE
Exporting explicit include dir for packages that need to pass it on to a...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,14 @@ catkin_simple()
 
 include(ExternalProject)
 link_directories(${CATKIN_DEVEL_PREFIX}/lib)
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 
 ExternalProject_Add(gflags_src
   SVN_REPOSITORY http://gflags.googlecode.com/svn/trunk/
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND cd ../gflags_src && ./autogen.sh && ./configure --with-pic GFLAGS_NAMESPACE=gflags --prefix=${CATKIN_DEVEL_PREFIX}
+  CONFIGURE_COMMAND cd ../gflags_src && ./autogen.sh && 
+    ./configure --with-pic GFLAGS_NAMESPACE=gflags 
+      --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../gflags_src && make -j8
   INSTALL_COMMAND cd ../gflags_src && make install -j8
 )

--- a/cmake/gflags-extras.cmake.in
+++ b/cmake/gflags-extras.cmake.in
@@ -1,3 +1,4 @@
-
 # This overrides the dependency tracker with the gflags library file.
-set( @PROJECT_NAME@_LIBRARIES ${CATKIN_DEVEL_PREFIX}/lib/libgflags${CMAKE_SHARED_LIBRARY_SUFFIX} )
+set(@PROJECT_NAME@_LIBRARIES 
+  ${CATKIN_DEVEL_PREFIX}/lib/libgflags${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(@PROJECT_NAME@_INCLUDE_DIR ${CATKIN_DEVEL_PREFIX}/include)


### PR DESCRIPTION
...n external project (e.g. ceres_catkin), mkdir -p for devel/include.
