### PR TITLE
https to http for libcurl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 
 ExternalProject_Add(
   gflags_src
-  URL https://github.com/gflags/gflags/archive/v2.1.2.zip
+  URL http://github.com/gflags/gflags/archive/v2.1.2.zip
   URL_MD5 5cb0a1b38740ed596edb7f86cd5b3bd8
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND cd ../gflags_src &&


### PR DESCRIPTION
We started getting this:
```
log: Protocol "https" not supported or disabled in libcurl
```
Changed this since I guess this shouldn't be an issue for anyone? Download works just as fine.